### PR TITLE
🐛 Remove `<h6>` element

### DIFF
--- a/src/components/register/Register.jsx
+++ b/src/components/register/Register.jsx
@@ -61,9 +61,6 @@ const Register = () => {
       <div className="container">
         <h2 className="title">Register</h2>
         <Form onSubmit={handleFormSubmit}>
-          <h6 className="subtitle">
-            Please enter your details below to register yourself.
-          </h6>
           {successMsg && <Alert variant="success">{successMsg}</Alert>}
           {errorMsg && <Alert variant="danger">{errorMsg}</Alert>}
           <Form.Group className="mb-3" controlId="name">


### PR DESCRIPTION
Hey, thanks so much for creating the tutorial on [freecodecamp](https://www.freecodecamp.org/news/write-unit-tests-using-react-testing-library/). This PR addresses an issue experienced when following along with that tutorial.

As instructed, I copied the `Register.jsx` code from your repo using the link you provided. Upon running the first jest test, it immediately failed. This wasn't very encouraging! I'm quite glad that I persevered though because I later discovered that this first test failed because your repo already includes the `<h6>` element which you later instruct the reader to add themselves.

So, as the commit says: the `<h6>`  element should not pre-exist in the repo, otherwise the very first test in the tutorial fails. This PR fixes the issue.

Thanks again for kindly creating the tutorial. Keep them coming!